### PR TITLE
Fixes #10 -  Added support for TOML Front Matter syntax highlighting in Markdown files 

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,13 @@
                 "language": "toml",
                 "scopeName": "source.toml",
                 "path": "./syntaxes/TOML.tmLanguage"
+            },
+            {
+                "scopeName": "markdown.toml.frontmatter.codeblock",
+                "path": "./syntaxes/TOML.frontMatter.tmLanguage",
+                "injectTo": [
+                    "text.html.markdown"
+                ]
             }
         ]
     },

--- a/syntaxes/TOML.YAML-tmLanguage
+++ b/syntaxes/TOML.YAML-tmLanguage
@@ -6,7 +6,6 @@ patterns:
     - include: '#comments'
     - include: '#tables'
     - include: '#keys'
-    - include: '#illegal'
 repository:
     array:
         begin: '(?<!\w)(\[)\s*'

--- a/syntaxes/TOML.frontMatter.YAML-tmLanguage
+++ b/syntaxes/TOML.frontMatter.YAML-tmLanguage
@@ -1,0 +1,12 @@
+fileTypes: []
+injectionSelector: 'L:text.html.markdown'
+patterns:
+    - include: '#toml-frontmatter-code-block'
+repository:
+    toml-frontmatter-code-block:
+        begin: '\A\+{3}\s*$'
+        end: '(^|\G)(?=\s*[\+~]{3,}\s*$)'
+        contentName: meta.embedded.block.toml.frontmatter
+        patterns:
+            - include: source.toml
+scopeName: markdown.toml.frontmatter.codeblock

--- a/syntaxes/TOML.frontMatter.tmLanguage
+++ b/syntaxes/TOML.frontMatter.tmLanguage
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>fileTypes</key>
+    <array/>
+    <key>injectionSelector</key>
+    <string>L:text.html.markdown</string>
+    <key>patterns</key>
+    <array>
+      <dict>
+        <key>include</key>
+        <string>#toml-frontmatter-code-block</string>
+      </dict>
+    </array>
+    <key>repository</key>
+    <dict>
+      <key>toml-frontmatter-code-block</key>
+      <dict>
+        <key>begin</key>
+        <string>\A\+{3}\s*$</string>
+        <key>end</key>
+        <string>(^|\G)(?=\s*[\+~]{3,}\s*$)</string>
+        <key>contentName</key>
+        <string>meta.embedded.block.toml.frontmatter</string>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>source.toml</string>
+          </dict>
+        </array>
+      </dict>
+    </dict>
+    <key>scopeName</key>
+    <string>markdown.toml.frontmatter.codeblock</string>
+  </dict>
+</plist>

--- a/syntaxes/TOML.tmLanguage
+++ b/syntaxes/TOML.tmLanguage
@@ -23,10 +23,6 @@
         <key>include</key>
         <string>#keys</string>
       </dict>
-      <dict>
-        <key>include</key>
-        <string>#illegal</string>
-      </dict>
     </array>
     <key>repository</key>
     <dict>


### PR DESCRIPTION
**Fixes #10** 
**Refrences: [VSCode Issue#41650](https://github.com/Microsoft/vscode/issues/41650)**

This feature injects Front Matter TOML syntax highlighting into Markdown files. 
A valid code block will be detected at the top line of a Markdown file.

```
+++
name = "better-toml"
+++
```

ex.
![image](https://user-images.githubusercontent.com/15523758/36289650-11824f82-128f-11e8-830f-331fa6245b85.png)