### PR TITLE
Recognize Python's Pipfile as a TOML file

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
           "toml"
         ],
         "extensions": [
-          ".toml"
+          ".toml",
+          "Pipfile"
         ],
         "mimetypes": [
           "text/x-toml"


### PR DESCRIPTION
To help address Microsoft/vscode-python#995