### PR TITLE
Update bombadil dependency to attempt supporting dotted keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "dependencies": {
-    "@sgarciac/bombadil": "0.0.7",
+    "@sgarciac/bombadil": "2.3.0",
     "node-fetch": "^2.1.2",
     "request-light": "^0.2.2",
     "vscode-json-languageservice": "^3.1.0",


### PR DESCRIPTION
**Note:** I haven't tested whether this actually fixes #18, I'm just following the advice from https://github.com/bungcip/better-toml/issues/18#issuecomment-531501071.

See #18.